### PR TITLE
fix: `resolution` -> `size`

### DIFF
--- a/src/to_makie.jl
+++ b/src/to_makie.jl
@@ -79,8 +79,8 @@ function MakieCore.Theme(
         end
         width *= width_coeff
         height = width * subplot_height_to_width_ratio * nrows / ncols
-        resolution = (width * POINTS_PER_INCH, height * POINTS_PER_INCH)
-        theme = merge(MakieCore.Theme(resolution = resolution), theme)
+        size = (width * POINTS_PER_INCH, height * POINTS_PER_INCH)
+        theme = merge(MakieCore.Theme(size = size), theme)
     end
 
     if thinned

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 MakieCore = "20f20a25-4f0e-4fdf-b5d1-57303727442b"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,16 @@ using TuePlots
 using Test, SafeTestsets, Aqua
 import MakieCore, Plots
 
+using CairoMakie
+
+function makie_plot(s)
+    with_theme(MakieCore.Theme(s)) do
+        lines(1:4, 1:4)
+    end
+
+    current_figure()
+end
+
 @testset "TuePlots.jl" begin
     setting_keys = TuePlots.get_available_settings()
 
@@ -14,6 +24,8 @@ import MakieCore, Plots
             else
                 @test_throws ErrorException MakieCore.Theme(s; single_column = true)
             end
+
+            @test makie_plot(s) isa Makie.Figure
         end
     end
 


### PR DESCRIPTION
Makie v0.20.0 deprecated the `resolution` argument, replacing it with `size` [1].  This causes Makie to emit deprecation warnings when a theme from TuePlots is loaded.

Change that argument in TuePlots too.

[1]: https://github.com/MakieOrg/Makie.jl/releases/tag/v0.20.0