### PR TITLE
add themes for JHEP and JCAP

### DIFF
--- a/src/settings.jl
+++ b/src/settings.jl
@@ -71,6 +71,18 @@ SETTINGS = Dict(
         base_fontsize = 9,
         font = "TeX Computer Modern",
     ),
+    :JCAP => TuePlotsSetting(
+        width = 6.08948,
+        width_half = nothing,
+        base_fontsize = 11,
+        font = "TeX Computer Modern",
+    ),
+    :JHEP => TuePlotsSetting(
+        width = 5.95393,
+        width_half = nothing,
+        base_fontsize = 11,
+        font = "TeX Computer Modern",
+    ),
 )
 
 """


### PR DESCRIPTION
JCAP (Journal of Cosmology and Astroparticle Physics) and JHEP (Journal of High Energy Physics) are physics journals.  They use the LaTeX styles [`jcappub.sty`](https://jcap.sissa.it/jcap/help/JCAP_TeXclass.jsp) and [`jheppub.sty`](https://jhep.sissa.it/jhep/help/JHEP_TeXclass.jsp).

Add settings with figure widths based on the output of
```
linewidth=\uselengthunit{pt}\printlength{\linewidth}
\\
linewidth=\uselengthunit{in}\printlength{\linewidth}
```
within figures with in documents with these styles.

For JCAP these are
```
440.0pt
6.08948in
```

For JHEP these are
```
430.20639pt
5.95393in
```


