### PR TITLE
CI: Add a job to check downgraded dependencies

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - 'ci/*'
     tags: '*'
   pull_request:
 concurrency:
@@ -39,6 +40,22 @@ jobs:
           files: lcov.info
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  downgrade:
+    name: Downgrade Compat
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: '1'
+      - uses: julia-actions/cache@v1
+      - uses: julia-actions/julia-downgrade-compat@v1
+        with:
+          skip: Pkg, TOML, Dates, LinearAlgebra, Random, Statistics, Test
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+
   docs:
     name: Documentation
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add a CI job that checks the oldest versions of dependencies that Project.toml claims are compatible.  This avoids unknown breakages due to using new features of packages and only testing against newest versions - like in #19.

It may make sense to merge this before #19. 