### PR TITLE
fix: Consistent font for Colorbar

### DIFF
--- a/src/to_makie.jl
+++ b/src/to_makie.jl
@@ -32,6 +32,10 @@ function MakieCore.Theme(
                     titlefont = setting.font,
                     labelfont = setting.font,
                 ),
+                Colorbar = (
+                    labelfont = setting.font,
+                    ticklabelfont = setting.font,
+                )
             ),
             theme,
         )

--- a/src/to_makie.jl
+++ b/src/to_makie.jl
@@ -35,7 +35,7 @@ function MakieCore.Theme(
                 Colorbar = (
                     labelfont = setting.font,
                     ticklabelfont = setting.font,
-                )
+                ),
             ),
             theme,
         )


### PR DESCRIPTION
The colorbar does not have the font set.  Set it the same way as for other plot elements fonts.