### PR TITLE
widen Legend patches in thinned theme

### DIFF
--- a/docs/src/example_makie.md
+++ b/docs/src/example_makie.md
@@ -71,7 +71,7 @@ T2 = Theme(
     ),
     Legend = (
         framewidth = 0.5,
-        patchsize = (8, 8),
+        patchsize = (20, 8),
         padding = (5, 5, 5, 5),
     ),
 )

--- a/src/opinions.jl
+++ b/src/opinions.jl
@@ -17,7 +17,7 @@ const MakieThinTheme = MakieCore.Theme(
     ),
     Legend = (
         framewidth = 0.5,
-        patchsize = (8, 8),
+        patchsize = (20, 8),
         padding = (5, 5, 5, 5),
     ),
     Colorbar = (;


### PR DESCRIPTION
The thinned theme changes the size of patches in `Legend`s.  This means that the `:solid`, `:dash` and `:dot` lifestyles are hard to distinguish.

Widen `patchsize` from (8, 8)` to `(20, 8)`.

There may be some reason I'm unaware of for not doing this.